### PR TITLE
Fixes th.pvtRowTotalLabel rowspan being 2 too high

### DIFF
--- a/multifact-pivottable.js
+++ b/multifact-pivottable.js
@@ -640,7 +640,7 @@
 
                 th.setAttribute("colspan", valueAttrs.length-numHiddenMeasures);
                 //Added 1 for value headers
-                th.setAttribute("rowspan", 2 + colAttrs.length + (rowAttrs.length === 0 ? 0 : 1));
+                th.setAttribute("rowspan", colAttrs.length + (rowAttrs.length === 0 ? 0 : 1));
                 tr.appendChild(th);
             }
         }


### PR DESCRIPTION
_th.pvtTotalLabel.pvtRowTotalLabel_ had a rowspan of 2 too high. 

This would break excel output exporting when using "table-to-excel" library on the underlying _table.pvtTable_ element.