### PR TITLE
Corrects wrong assignment for getMouseMoveHandler

### DIFF
--- a/multifact-pivottable.js
+++ b/multifact-pivottable.js
@@ -844,7 +844,7 @@
                         }
 
                         if (getMouseMoveHandler != null) {
-                            td.onmouseleave = getMouseMoveHandler(val, rowKey, colKey);
+                            td.onmousemove = getMouseMoveHandler(val, rowKey, colKey);
 
                         }
                         tr.appendChild(td);


### PR DESCRIPTION
Hello!

I've made a simple change that should fix a bug where the `getMouseMoveHandler` was being incorrectly assigned to `onmouseleave` instead of `onmousemove`.

For testing I just opened `examples/3_hover-tooltip.html` and added the following:

```
                mouseMoveCallback : function(e, value, filters, pivotData){
                    console.log('hello');
                }
```

Before you'd see `hello` when leaving the cell. With the change you should see the console.log whenever the mouse moves.